### PR TITLE
Webhook Event Metrics

### DIFF
--- a/eventsources/events.go
+++ b/eventsources/events.go
@@ -3,6 +3,7 @@ package eventsources
 import (
 	"github.com/opentracing/opentracing-go"
 	"net/http"
+	"time"
 )
 
 type SpanState string
@@ -21,6 +22,12 @@ const (
 	UnknownState      SpanState = "unknown"
 )
 
+type EventTimings interface {
+	StartTime() time.Time
+	EndTime() time.Time
+	Duration() time.Duration
+}
+
 type Event interface {
 	SpanID() (string, error)
 	OperationName() string
@@ -28,6 +35,7 @@ type Event interface {
 	IsError() (bool, error)
 	State(prev *EventState) (SpanState, error)
 	Tags() (map[string]interface{}, error)
+	Timings() EventTimings
 }
 
 type EventSource interface {

--- a/eventsources/events.go
+++ b/eventsources/events.go
@@ -22,10 +22,10 @@ const (
 	UnknownState      SpanState = "unknown"
 )
 
-type EventTimings interface {
-	StartTime() time.Time
-	EndTime() time.Time
-	Duration() time.Duration
+type EventTimings struct {
+	StartTime *time.Time
+	EndTime   *time.Time
+	Duration  *time.Duration
 }
 
 type Event interface {
@@ -35,7 +35,7 @@ type Event interface {
 	IsError() (bool, error)
 	State(prev *EventState) (SpanState, error)
 	Tags() (map[string]interface{}, error)
-	Timings() EventTimings
+	Timings() (EventTimings, error)
 }
 
 type EventSource interface {

--- a/eventsources/github/events.go
+++ b/eventsources/github/events.go
@@ -15,7 +15,22 @@ type IssuesEvent struct {
 	*github.IssuesEvent
 }
 
-func (ie IssuesEvent) Timings() eventsources.EventTimings { return nil }
+// Timings parses github event data for start time, end time
+// and calculates the duration.
+func (ie IssuesEvent) Timings() (eventsources.EventTimings, error) {
+	action := *ie.Action
+	timings := eventsources.EventTimings{
+		StartTime: ie.Issue.CreatedAt,
+	}
+
+	if action == "closed" {
+		timings.EndTime = ie.Issue.ClosedAt
+		diff := timings.EndTime.Sub(*timings.StartTime)
+		timings.Duration = &diff
+	}
+
+	return timings, nil
+}
 
 func (ie IssuesEvent) OperationName() string {
 	return "issue"
@@ -100,7 +115,20 @@ type PREvent struct {
 	*github.PullRequestEvent
 }
 
-func (pr PREvent) Timings() eventsources.EventTimings { return nil }
+func (pr PREvent) Timings() (eventsources.EventTimings, error) {
+	action := *pr.Action
+	timings := eventsources.EventTimings{
+		StartTime: pr.PullRequest.CreatedAt,
+	}
+
+	if action == "closed" {
+		timings.EndTime = pr.PullRequest.ClosedAt
+		diff := timings.EndTime.Sub(*timings.StartTime)
+		timings.Duration = &diff
+	}
+
+	return timings, nil
+}
 
 func (pr PREvent) OperationName() string {
 	return "pull_request"

--- a/eventsources/github/events.go
+++ b/eventsources/github/events.go
@@ -15,6 +15,8 @@ type IssuesEvent struct {
 	*github.IssuesEvent
 }
 
+func (ie IssuesEvent) Timings() eventsources.EventTimings { return nil }
+
 func (ie IssuesEvent) OperationName() string {
 	return "issue"
 }
@@ -97,6 +99,8 @@ func (ie IssuesEvent) Tags() (map[string]interface{}, error) {
 type PREvent struct {
 	*github.PullRequestEvent
 }
+
+func (pr PREvent) Timings() eventsources.EventTimings { return nil }
 
 func (pr PREvent) OperationName() string {
 	return "pull_request"

--- a/eventsources/github/events_test.go
+++ b/eventsources/github/events_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestPullRequestEvent_ParentSpanID(t *testing.T) {
@@ -36,4 +37,48 @@ func TestPullRequestEvent_ParentSpanID(t *testing.T) {
 			assert.Equal(t, tt.expected, *match)
 		})
 	}
+}
+
+func TestIssuesEvent_Duration(t *testing.T) {
+	created := time.Date(
+		2000, 12, 1, 0, 0, 0, 0, time.UTC,
+	)
+	end := time.Date(
+		2000, 12, 1, 1, 0, 0, 0, time.UTC,
+	)
+	closed := "closed"
+	ie := IssuesEvent{
+		&github.IssuesEvent{
+			Action: &closed,
+			Issue: &github.Issue{
+				CreatedAt: &created,
+				ClosedAt:  &end,
+			},
+		},
+	}
+	timings, err := ie.Timings()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), (*timings.Duration).Hours())
+}
+
+func TestPREvent_Duration(t *testing.T) {
+	created := time.Date(
+		2000, 12, 1, 0, 0, 0, 0, time.UTC,
+	)
+	end := time.Date(
+		2000, 12, 1, 1, 0, 0, 0, time.UTC,
+	)
+	closed := "closed"
+	pr := PREvent{
+		&github.PullRequestEvent{
+			Action: &closed,
+			PullRequest: &github.PullRequest{
+				CreatedAt: &created,
+				ClosedAt:  &end,
+			},
+		},
+	}
+	timings, err := pr.Timings()
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), (*timings.Duration).Hours())
 }

--- a/eventsources/gitlab/events.go
+++ b/eventsources/gitlab/events.go
@@ -15,7 +15,7 @@ type IssueEvent struct {
 	*gitlab.IssueEvent
 }
 
-func (ie IssueEvent) Timings() eventsources.EventTimings { return nil }
+func (ie IssueEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
 
 func (ie IssueEvent) OperationName() string {
 	return types.IssueEventType
@@ -97,7 +97,7 @@ type MergeEvent struct {
 	*gitlab.MergeEvent
 }
 
-func (me MergeEvent) Timings() eventsources.EventTimings { return nil }
+func (me MergeEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
 
 func (me MergeEvent) OperationName() string {
 	return types.PullRequestEventType
@@ -180,7 +180,7 @@ type PipelineEvent struct {
 	*gitlab.PipelineEvent
 }
 
-func (pe PipelineEvent) Timings() eventsources.EventTimings { return nil }
+func (pe PipelineEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
 
 func (pe PipelineEvent) OperationName() string {
 	return "pipeline"
@@ -274,7 +274,7 @@ type JobEvent struct {
 	*gitlab.JobEvent
 }
 
-func (je JobEvent) Timings() eventsources.EventTimings { return nil }
+func (je JobEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
 
 func (je JobEvent) OperationName() string {
 	return types.BuildEventType

--- a/eventsources/gitlab/events.go
+++ b/eventsources/gitlab/events.go
@@ -15,7 +15,9 @@ type IssueEvent struct {
 	*gitlab.IssueEvent
 }
 
-func (ie IssueEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
+func (ie IssueEvent) Timings() (eventsources.EventTimings, error) {
+	return eventsources.EventTimings{}, nil
+}
 
 func (ie IssueEvent) OperationName() string {
 	return types.IssueEventType
@@ -97,7 +99,9 @@ type MergeEvent struct {
 	*gitlab.MergeEvent
 }
 
-func (me MergeEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
+func (me MergeEvent) Timings() (eventsources.EventTimings, error) {
+	return eventsources.EventTimings{}, nil
+}
 
 func (me MergeEvent) OperationName() string {
 	return types.PullRequestEventType
@@ -180,7 +184,9 @@ type PipelineEvent struct {
 	*gitlab.PipelineEvent
 }
 
-func (pe PipelineEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
+func (pe PipelineEvent) Timings() (eventsources.EventTimings, error) {
+	return eventsources.EventTimings{}, nil
+}
 
 func (pe PipelineEvent) OperationName() string {
 	return "pipeline"
@@ -274,7 +280,9 @@ type JobEvent struct {
 	*gitlab.JobEvent
 }
 
-func (je JobEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
+func (je JobEvent) Timings() (eventsources.EventTimings, error) {
+	return eventsources.EventTimings{}, nil
+}
 
 func (je JobEvent) OperationName() string {
 	return types.BuildEventType

--- a/eventsources/gitlab/events.go
+++ b/eventsources/gitlab/events.go
@@ -15,6 +15,8 @@ type IssueEvent struct {
 	*gitlab.IssueEvent
 }
 
+func (ie IssueEvent) Timings() eventsources.EventTimings { return nil }
+
 func (ie IssueEvent) OperationName() string {
 	return types.IssueEventType
 }
@@ -94,6 +96,8 @@ func (ie IssueEvent) Tags() (map[string]interface{}, error) {
 type MergeEvent struct {
 	*gitlab.MergeEvent
 }
+
+func (me MergeEvent) Timings() eventsources.EventTimings { return nil }
 
 func (me MergeEvent) OperationName() string {
 	return types.PullRequestEventType
@@ -175,6 +179,8 @@ func (me MergeEvent) Tags() (map[string]interface{}, error) {
 type PipelineEvent struct {
 	*gitlab.PipelineEvent
 }
+
+func (pe PipelineEvent) Timings() eventsources.EventTimings { return nil }
 
 func (pe PipelineEvent) OperationName() string {
 	return "pipeline"
@@ -267,6 +273,8 @@ func (pe PipelineEvent) Tags() (map[string]interface{}, error) {
 type JobEvent struct {
 	*gitlab.JobEvent
 }
+
+func (je JobEvent) Timings() eventsources.EventTimings { return nil }
 
 func (je JobEvent) OperationName() string {
 	return types.BuildEventType

--- a/eventsources/gitlab/events_test.go
+++ b/eventsources/gitlab/events_test.go
@@ -1,0 +1,9 @@
+package gitlab
+
+import (
+	"testing"
+)
+
+func TestIssueEvent_Timings_Duration(t *testing.T) {
+	t.Skip()
+}

--- a/eventsources/http/events.go
+++ b/eventsources/http/events.go
@@ -15,6 +15,8 @@ type Event struct {
 	Metadata   map[string]interface{}
 }
 
+func (e Event) Timings() eventsources.EventTimings { return nil }
+
 // ID is how an INDIVIDUAL event is referenced internally
 func (e Event) SpanID() (string, error) {
 

--- a/eventsources/http/events.go
+++ b/eventsources/http/events.go
@@ -15,7 +15,7 @@ type Event struct {
 	Metadata   map[string]interface{}
 }
 
-func (e Event) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
+func (e Event) Timings() (eventsources.EventTimings, error) { return eventsources.EventTimings{}, nil }
 
 // ID is how an INDIVIDUAL event is referenced internally
 func (e Event) SpanID() (string, error) {

--- a/eventsources/http/events.go
+++ b/eventsources/http/events.go
@@ -15,7 +15,7 @@ type Event struct {
 	Metadata   map[string]interface{}
 }
 
-func (e Event) Timings() eventsources.EventTimings { return nil }
+func (e Event) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
 
 // ID is how an INDIVIDUAL event is referenced internally
 func (e Event) SpanID() (string, error) {

--- a/eventsources/jenkins/events.go
+++ b/eventsources/jenkins/events.go
@@ -42,7 +42,7 @@ type BuildEvent struct {
 	EndTime       int      `json:"endTime"`
 }
 
-func (be BuildEvent) Timings() eventsources.EventTimings { return nil }
+func (be BuildEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
 
 func (be BuildEvent) SpanID() (string, error) {
 	id := strings.Join([]string{

--- a/eventsources/jenkins/events.go
+++ b/eventsources/jenkins/events.go
@@ -42,6 +42,8 @@ type BuildEvent struct {
 	EndTime       int      `json:"endTime"`
 }
 
+func (be BuildEvent) Timings() eventsources.EventTimings { return nil }
+
 func (be BuildEvent) SpanID() (string, error) {
 	id := strings.Join([]string{
 		eventsources.TracePrefix,

--- a/eventsources/jenkins/events.go
+++ b/eventsources/jenkins/events.go
@@ -42,7 +42,9 @@ type BuildEvent struct {
 	EndTime       int      `json:"endTime"`
 }
 
-func (be BuildEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
+func (be BuildEvent) Timings() (eventsources.EventTimings, error) {
+	return eventsources.EventTimings{}, nil
+}
 
 func (be BuildEvent) SpanID() (string, error) {
 	id := strings.Join([]string{

--- a/eventsources/jiracloud/events.go
+++ b/eventsources/jiracloud/events.go
@@ -46,7 +46,7 @@ type SprintEvent struct {
 	Sprint jira.Sprint
 }
 
-func (se SprintEvent) Timings() eventsources.EventTimings { return nil }
+func (se SprintEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
 
 func (se SprintEvent) SpanID() (string, error) {
 	return strings.Join([]string{
@@ -99,7 +99,7 @@ type IssueEvent struct {
 	Changelog jira.Changelog
 }
 
-func (ie IssueEvent) Timings() eventsources.EventTimings { return nil }
+func (ie IssueEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
 
 func (ie IssueEvent) SpanID() (string, error) {
 	return strings.Join([]string{

--- a/eventsources/jiracloud/events.go
+++ b/eventsources/jiracloud/events.go
@@ -46,6 +46,8 @@ type SprintEvent struct {
 	Sprint jira.Sprint
 }
 
+func (se SprintEvent) Timings() eventsources.EventTimings { return nil }
+
 func (se SprintEvent) SpanID() (string, error) {
 	return strings.Join([]string{
 		"vstrace",
@@ -96,6 +98,8 @@ type IssueEvent struct {
 	Issue     jira.Issue
 	Changelog jira.Changelog
 }
+
+func (ie IssueEvent) Timings() eventsources.EventTimings { return nil }
 
 func (ie IssueEvent) SpanID() (string, error) {
 	return strings.Join([]string{

--- a/eventsources/jiracloud/events.go
+++ b/eventsources/jiracloud/events.go
@@ -46,7 +46,9 @@ type SprintEvent struct {
 	Sprint jira.Sprint
 }
 
-func (se SprintEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
+func (se SprintEvent) Timings() (eventsources.EventTimings, error) {
+	return eventsources.EventTimings{}, nil
+}
 
 func (se SprintEvent) SpanID() (string, error) {
 	return strings.Join([]string{
@@ -99,7 +101,9 @@ type IssueEvent struct {
 	Changelog jira.Changelog
 }
 
-func (ie IssueEvent) Timings() eventsources.EventTimings { return eventsources.EventTimings{} }
+func (ie IssueEvent) Timings() (eventsources.EventTimings, error) {
+	return eventsources.EventTimings{}, nil
+}
 
 func (ie IssueEvent) SpanID() (string, error) {
 	return strings.Join([]string{

--- a/eventsources/testing.go
+++ b/eventsources/testing.go
@@ -74,7 +74,7 @@ func (s StubEvent) Tags() (map[string]interface{}, error) {
 	return s.TagsReturn, s.TagsReturnError
 }
 
-func (s StubEvent) Timings() EventTimings { return EventTimings{} }
+func (s StubEvent) Timings() (EventTimings, error) { return EventTimings{}, nil }
 
 type TestEvent struct {
 	Headers map[string]string

--- a/eventsources/testing.go
+++ b/eventsources/testing.go
@@ -74,6 +74,8 @@ func (s StubEvent) Tags() (map[string]interface{}, error) {
 	return s.TagsReturn, s.TagsReturnError
 }
 
+func (s StubEvent) Timings() EventTimings { return nil }
+
 type TestEvent struct {
 	Headers map[string]string
 	Payload interface{}

--- a/eventsources/testing.go
+++ b/eventsources/testing.go
@@ -74,7 +74,7 @@ func (s StubEvent) Tags() (map[string]interface{}, error) {
 	return s.TagsReturn, s.TagsReturnError
 }
 
-func (s StubEvent) Timings() EventTimings { return nil }
+func (s StubEvent) Timings() EventTimings { return EventTimings{} }
 
 type TestEvent struct {
 	Headers map[string]string

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/uber/jaeger-lib v2.0.0+incompatible // indirect
 	github.com/urfave/cli v1.22.2
 	github.com/urfave/cli/v2 v2.0.0
-	github.com/xanzy/go-gitlab v0.22.0
+	github.com/xanzy/go-gitlab v0.22.2
 	go.opencensus.io v0.22.2
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/urfave/cli/v2 v2.0.0 h1:+HU9SCbu8GnEUFtIBfuUNXN39ofWViIEJIp6SURMpCg=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/xanzy/go-gitlab v0.22.0 h1:36pMeB8I6pOe/olay52wAizhlqSApo3b32z9GKx4Pic=
 github.com/xanzy/go-gitlab v0.22.0/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
+github.com/xanzy/go-gitlab v0.22.2 h1:KYPewSm3Tl7WHrVON7BOwX6FZ1gaiFEdpOt0DNIYySA=
+github.com/xanzy/go-gitlab v0.22.2/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.2 h1:75k/FF0Q2YM8QYo07VPddOLBslDt1MZOdEslOHvmzAs=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -186,6 +188,7 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190719005602-e377ae9d6386/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/main.go
+++ b/main.go
@@ -82,6 +82,8 @@ func main() {
 			return err
 		}
 
+		go spans.Monitor(ctx, time.Second*5, "spans")
+
 		sources := []struct {
 			urlPath   string
 			name      string

--- a/main.go
+++ b/main.go
@@ -176,6 +176,7 @@ func main() {
 			ochttp.ServerLatencyView,
 			ochttp.ServerRequestCountByMethod,
 			ochttp.ServerResponseCountByStatusCode,
+			webhooks.EventStartCountView,
 		); err != nil {
 			return fmt.Errorf("failed to register ochttp Server views: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -161,9 +161,7 @@ func main() {
 			}
 		}
 
-		exporter, err := prometheus.NewExporter(prometheus.Options{
-			Namespace: "vs",
-		})
+		exporter, err := prometheus.NewExporter(prometheus.Options{})
 
 		if err != nil {
 			return fmt.Errorf("failed to create the Prometheus exporter: %v", err)

--- a/main.go
+++ b/main.go
@@ -178,6 +178,7 @@ func main() {
 			ochttp.ServerResponseCountByStatusCode,
 			webhooks.EventStartCountView,
 			webhooks.EventEndCountView,
+			webhooks.EventLatencyView,
 		); err != nil {
 			return fmt.Errorf("failed to register ochttp Server views: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -177,6 +177,7 @@ func main() {
 			ochttp.ServerRequestCountByMethod,
 			ochttp.ServerResponseCountByStatusCode,
 			webhooks.EventStartCountView,
+			webhooks.EventEndCountView,
 		); err != nil {
 			return fmt.Errorf("failed to register ochttp Server views: %v", err)
 		}

--- a/traces/stores.go
+++ b/traces/stores.go
@@ -5,35 +5,42 @@ import (
 	"fmt"
 	"github.com/ImpactInsights/valuestream/eventsources"
 	"github.com/opentracing/opentracing-go"
-	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 	"sync"
 	"time"
 )
 
 var (
-	bufferedSpansTotal = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "buffered_spans_total",
-			Help: "Gauge total number of current buffered spans",
-		},
-		[]string{"buffer_name"},
-	)
-	bufferedSpansPercentage = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "buffered_spans_percentage",
-			Help: "Gauge percentage of buffer in use",
-		},
-		[]string{"buffer_name"},
-	)
-)
+	bufferName, _ = tag.NewKey("buffer_name")
 
-func init() {
-	prometheus.MustRegister(
-		bufferedSpansTotal,
-		bufferedSpansPercentage,
+	BufferedSpansTotal = stats.Float64(
+		"traces/stores/buffered_spans/total",
+		"Gauge total number of current buffered spans",
+		stats.UnitDimensionless,
 	)
-}
+	BufferedSpansTotalView = &view.View{
+		Name:        "traces/stores/buffered_spans/total",
+		Description: "Gauge total number of current buffered spans",
+		TagKeys:     []tag.Key{bufferName},
+		Measure:     BufferedSpansTotal,
+		Aggregation: view.LastValue(),
+	}
+	BufferedSpansPercentage = stats.Float64(
+		"traces/stores/buffered_spans/percentage",
+		"Gauge percentage full current buffer",
+		stats.UnitDimensionless,
+	)
+	BufferedSpansPercentageView = &view.View{
+		Name:        "traces/stores/buffered_spans/percentage",
+		Description: "Gauge percentage full current buffer",
+		TagKeys:     []tag.Key{bufferName},
+		Measure:     BufferedSpansPercentage,
+		Aggregation: view.LastValue(),
+	}
+)
 
 type StoreEntry struct {
 	Span      opentracing.Span
@@ -166,6 +173,10 @@ func (s *BufferedSpans) DeleteAll(ctx context.Context) error {
 
 func (s *BufferedSpans) Monitor(ctx context.Context, interval time.Duration, name string) {
 	ticker := time.NewTicker(interval)
+	ctx, _ = tag.New(ctx,
+		tag.Insert(bufferName, name),
+	)
+
 	for {
 		select {
 		case <-ticker.C:
@@ -181,8 +192,8 @@ func (s *BufferedSpans) Monitor(ctx context.Context, interval time.Duration, nam
 				"name":              name,
 			}).Info("buffered_spans_state")
 
-			bufferedSpansTotal.With(prometheus.Labels{"buffer_name": name}).Set(currSize)
-			bufferedSpansPercentage.With(prometheus.Labels{"buffer_name": name}).Set(percentage)
+			stats.Record(ctx, BufferedSpansTotal.M(currSize))
+			stats.Record(ctx, BufferedSpansPercentage.M(percentage))
 		case <-ctx.Done():
 			ticker.Stop()
 			return

--- a/traces/stores.go
+++ b/traces/stores.go
@@ -36,8 +36,20 @@ func init() {
 }
 
 type StoreEntry struct {
-	Span  opentracing.Span
-	State *eventsources.EventState
+	Span      opentracing.Span
+	State     *eventsources.EventState
+	CreatedAt time.Time
+}
+
+func NewStoreEntryFromSpan(span opentracing.Span) StoreEntry {
+	return StoreEntry{
+		Span:      span,
+		CreatedAt: time.Now().UTC(),
+	}
+}
+
+func (se StoreEntry) Duration() time.Duration {
+	return time.Now().Sub(se.CreatedAt)
 }
 
 type SpanStore interface {


### PR DESCRIPTION
refs #45

- [x] startevent metrics
- [x] Update `BufferedSpans.Monitor()` prometheus metrics to use opencensus
- [x] end event count metrics
  - (source, type, error)
- [x] end event duration metrics
  - (source, type, error, duration)