### PR TITLE
Adds enterprise project support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ $ ~/ngrok http 5000
 
 ## CLI
 
-ValueStream offers a CLI for pulling data and generating offline performance reports.  Generating a report requires pulling the raw pull request information from a third-party api (GitHub in this case). The following command pulls merged prs inbatches of 10 using the GitHub api. Outputs:
+ValueStream offers a CLI for pulling data and generating offline performance reports. Generating a report requires 
+pulling the raw pull request information from a third-party api (GitHub in this case). The following command pulls 
+merged prs inbatches of 10 using the GitHub API.
+
+You must have an access token in order to access the GitHub API. Set the `VS_PERF_REPORT_GITHUB_ACCESS_TOKEN` environment 
+variable or invoke `github pull-requests` with `--access-token`.
 
 ```
 $ go run cmd/vsperformancereport/main.go github pull-requests -org=ImpactInsights -pr-state=MERGED -out=/tmp/vs-prs.csv -prs-per-page=10 -repo=valuestream
@@ -68,9 +73,7 @@ INFO[0000] PullRequests.List                             is_last=false page=1
 INFO[0001] PullRequests.List                             is_last=false page=2
 INFO[0001] PullRequests.List                             is_last=true page=3
 ```
-**Private Repos**
 
-Private repos can be accessed by setting the `VS_PERF_REPORT_GITHUB_ACCESS_TOKEN` environment variable or by invoking `github pull-requests` with `--access-token`
 
 Next is to generate [pull request performance metrics](https://medium.com/valuestream-by-operational-analytics-inc/using-code-review-metrics-as-performance-indicators-caa47a716297):
 

--- a/eventsources/github/report.go
+++ b/eventsources/github/report.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"fmt"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 	"net/http"
@@ -9,7 +10,7 @@ import (
 	"time"
 )
 
-func NewClient(ctx context.Context, accessToken string) *githubv4.Client {
+func NewClient(ctx context.Context, accessToken string, enterpriseDomain string) *githubv4.Client {
 	var tc *http.Client
 	if accessToken != "" {
 		ts := oauth2.StaticTokenSource(
@@ -18,7 +19,17 @@ func NewClient(ctx context.Context, accessToken string) *githubv4.Client {
 		tc = oauth2.NewClient(ctx, ts)
 	}
 
-	return githubv4.NewClient(tc)
+	if enterpriseDomain == "" {
+		return githubv4.NewClient(tc)
+	}
+
+	return githubv4.NewEnterpriseClient(
+		fmt.Sprintf("https://%s/api/graphql",
+			enterpriseDomain,
+		),
+		tc,
+	)
+
 }
 
 /*


### PR DESCRIPTION
refs #72

This adds enterprise project support using the strategy by @clcpolevaulter (https://github.com/ImpactInsights/valuestream/issues/72#issuecomment-703953185).

I tested this with a fake domain but was unable to test this against an actual enterprise deployment:

```
$ go run cmd/vsperformancereport/main.go github pull-requests -org=ImpactInsights -pr-state=MERGED -prs-per-page=10 -repo=valuestream -enterprise-domain=ImpactInsights
FATA[0000] Post "https://ImpactInsights/api/graphql": dial tcp: lookup ImpactInsights: no such host
exit status 1
```